### PR TITLE
Adding a Gitpod yaml to make trying this out easier.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+tasks:
+  - init: |
+      go get
+      go build
+    command: |
+      gp open main.go
+      echo "go_tui is built and ready to try out. Type: ./go_tui"
+vscode:
+  extensions:
+    - golang.go

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Terminal Based Rolodex Built with [Tview](https://github.com/rivo/tview)
 
 This is just an example app. It does not persist any data. Follow along with the article on the [Earthly blog](https://earthly.dev/blog/tui-app-with-go/)
+
+# Try it out right now with Gitpod
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jalletto/tui-go-example)
+
+Nothing to pay for, just login with GitHub and you'll be up and running with this tutorial in a full Linux environment with VS Code and the Golang extensions.


### PR DESCRIPTION
Gitpod can often make trying tutorials out easier. This file would allow someone to checkout, build, edit, and run this tutorial in a browser based VS Code with the Golang extension preinstalled. You can try it out here: https://gitpod.io/#https://github.com/jalletto/tui-go-example

Users don't need to pay for anything. A GitHub account is all they need.

Please feel free to close this if its not useful.